### PR TITLE
Optimised `Registry::view()` so its not unusable in debug builds

### DIFF
--- a/include/exodus/ecs/registry.hpp
+++ b/include/exodus/ecs/registry.hpp
@@ -3,15 +3,92 @@
 
 // Std headers
 #include <algorithm>
-#include <cassert>
 #include <memory>
 #include <ranges>
 #include <vector>
 
 // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 namespace exodus::ecs {
+class Registry;
+
 /// Represents unique identifiers for game objects
 using GameObjectID = std::uint32_t;
+
+/// A view that allows iterating over game objects that have a specific set of components.
+template <typename... Component>
+class View {
+ public:
+  /// An iterator for iterating over the game objects in the view.
+  struct iterator {
+    using difference_type = std::ptrdiff_t;
+    using value_type = std::tuple<Component&...>;
+
+    /// The registry which manages the game objects and their components.
+    Registry* registry{};
+
+    /// A pointer to the game objects which are included in this view.
+    std::span<const GameObjectID> game_objects;
+
+    /// The current index of the iterator in the game objects vector.
+    std::size_t index{0};
+
+    /// Dereference the iterator to get a tuple of references to the components of the current game object.
+    ///
+    /// @return A tuple of references to the components of the current game object.
+    auto operator*() const;
+
+    /// Increment the iterator to move to the next game object in the view.
+    ///
+    /// @return A reference to the incremented iterator.
+    auto operator++() -> iterator& {
+      ++index;
+      return *this;
+    }
+
+    /// Post-increment the iterator to move to the next game object in the view.
+    ///
+    /// @return A copy of the iterator before incrementing.
+    auto operator++(int) -> iterator {
+      iterator tmp = *this;
+      ++*this;
+      return tmp;
+    }
+
+    /// Check if two iterators are equal by comparing their indices.
+    ///
+    /// @param other The other iterator to compare with.
+    auto operator==(const iterator& other) const -> bool { return index == other.index; }
+
+    /// Check if two iterators are not equal by comparing their indices.
+    ///
+    /// @param other The other iterator to compare with.
+    auto operator!=(const iterator& other) const -> bool { return index != other.index; }
+  };
+
+  /// Construct a view.
+  ///
+  /// @param registry The registry which manages the game objects and their components.
+  /// @param game_objects The game objects which are included in this view.
+  View(Registry* registry, const std::span<const GameObjectID>& game_objects)
+      : registry{registry}, game_objects{game_objects} {}
+
+  /// Get an iterator to the beginning of the view.
+  ///
+  /// @return An iterator to the beginning of the view.
+  auto begin() -> iterator { return {registry, game_objects, 0}; }
+
+  /// Get an iterator to the end of the view.
+  ///
+  /// @return An iterator to the end of the view.
+  auto end() -> iterator { return {registry, game_objects, game_objects.size()}; }
+
+ private:
+  /// The registry which manages the game objects and their components.
+  Registry* registry{};
+
+  /// The game objects which are included in this view.
+  std::span<const GameObjectID> game_objects;
+};
 
 /// Manages game objects and their components in the registry.
 class Registry {
@@ -22,6 +99,7 @@ class Registry {
   auto create() -> GameObjectID {
     const GameObjectID game_object_id{next_game_object_id_++};
     alive_.push_back(true);
+    dirty_views();
     return game_object_id;
   }
 
@@ -45,6 +123,7 @@ class Registry {
         storage->remove(game_object_id);
       }
     }
+    dirty_views();
     alive_[game_object_id] = false;
   }
 
@@ -62,14 +141,13 @@ class Registry {
   template <typename Component, typename... Args>
   void add_component(const GameObjectID game_object_id, Args&&... args) {
     // Make sure the storage has enough size for this game object
-    assert(has(game_object_id));
     auto& storage{get_storage<Component>()};
     if (game_object_id >= storage.sparse.size()) {
-      storage.sparse.resize(game_object_id + 1, INVALID_COMPONENT_INDEX);
+      storage.sparse.resize(game_object_id + 1, INVALID_INDEX);
     }
 
     // Stop if we already have this component
-    if (storage.sparse[game_object_id] != INVALID_COMPONENT_INDEX) {
+    if (storage.sparse[game_object_id] != INVALID_INDEX) {
       return;
     }
 
@@ -77,6 +155,7 @@ class Registry {
     storage.components.emplace_back(std::forward<Args>(args)...);
     storage.game_objects.emplace_back(game_object_id);
     storage.sparse[game_object_id] = storage.components.size() - 1;
+    dirty_views(type_id<Component, ComponentTag>());
   }
 
   /// Get a component from the registry for a given game object ID.
@@ -86,11 +165,8 @@ class Registry {
   /// @return A reference to the component of the given type for the specified game object ID.
   template <typename Component>
   auto get_component(const GameObjectID game_object_id) -> Component& {
-    assert(has(game_object_id));
     auto& storage{get_storage<Component>()};
-    assert(game_object_id < storage.sparse.size());
     const auto index{storage.sparse[game_object_id]};
-    assert(index != INVALID_COMPONENT_INDEX);
     return storage.components[index];
   }
 
@@ -105,45 +181,51 @@ class Registry {
     if (!has(game_object_id)) {
       return false;
     }
-    const std::size_t type_id{component_type_id<Component>()};
-    if (type_id >= storages_.size() || !storages_[type_id]) {
+    const std::size_t component_type_id{type_id<Component, ComponentTag>()};
+    if (component_type_id >= storages_.size() || !storages_[component_type_id]) {
       return false;
     }
 
     // Check if the game object has the component in the storage
-    const auto* storage{static_cast<Storage<Component>*>(storages_[type_id].get())};
-    return game_object_id < storage->sparse.size() && storage->sparse[game_object_id] != INVALID_COMPONENT_INDEX;
+    const auto* storage{static_cast<Storage<Component>*>(storages_[component_type_id].get())};
+    return game_object_id < storage->sparse.size() && storage->sparse[game_object_id] != INVALID_INDEX;
   }
 
   /// Create a view for iterating over game objects that have a specific set of components.
   ///
-  /// @tparam Component The types of components to include in the view.
+  /// @tparam Primary The type of the primary component to iterate over, which should be the component with the least
+  /// number of instances.
+  /// @tparam Rest The types of the other components to iterate over.
   /// @return A view that allows iterating over game objects that have the specified components.
-  template <typename... Component>
-  auto view() {
-    // Get all the storages for the given components
-    static_assert(sizeof...(Component) > 0, "Cannot create a view with no components");
-    auto storages{std::tie(get_storage<Component>()...)};
+  template <typename Primary, typename... Rest>
+  auto view() -> View<Primary, Rest...> {
+    // Resize the view cache if needed
+    const std::size_t view_type_id{type_id<std::tuple<Primary, Rest...>, ViewTag>()};
+    if (view_type_id >= view_cache_.size()) {
+      view_cache_.resize(view_type_id + 1);
+    }
+    auto& [game_objects, component_type_ids, dirty]{view_cache_[view_type_id]};
+    if (component_type_ids.empty()) {
+      component_type_ids = {type_id<Primary, ComponentTag>(), type_id<Rest, ComponentTag>()...};
+    }
 
-    // Get the primary storage which will act as the first component to iterate over. This should be the component with
-    // the least number of instances to minimise the number of iterations needed
-    auto& primary{std::get<0>(storages)};
-
-    // Create a lazy generator using a range
-    auto rng{std::views::iota(std::size_t{0}, primary.components.size()) |
-             std::views::filter([&](const std::size_t val) -> auto {
-               return (has_component<Component>(primary.game_objects[val]) && ...);
-             }) |
-             std::views::transform([&](std::size_t val) -> std::tuple<Component&...> {
-               return std::tuple<Component&...>{get_component<Component>(primary.game_objects[val])...};
-             })};
-    return rng;
+    // If it's dirty, recompute the game objects for this view
+    if (dirty) {
+      auto& primary{get_storage<Primary>()};
+      if constexpr (sizeof...(Rest) == 0) {
+        game_objects = std::vector<GameObjectID>(primary.game_objects.begin(), primary.game_objects.end());
+      } else {
+        auto filtered{primary.game_objects | std::views::filter([this](const GameObjectID game_object_id) {
+                        return (has_component<Rest>(game_object_id) && ...);
+                      })};
+        game_objects = std::vector<GameObjectID>(filtered.begin(), filtered.end());
+      }
+      dirty = false;
+    }
+    return View<Primary, Rest...>{this, game_objects};
   }
 
  private:
-  /// A constant representing an invalid component index in the sparse array.
-  inline static std::size_t INVALID_COMPONENT_INDEX{static_cast<std::size_t>(-1)};
-
   /// An interface for component storage, allowing for type-erased storage of different component types.
   struct IStorage {
     /// Create the storage.
@@ -173,8 +255,8 @@ class Registry {
   /// Storage model:
   /// - Each component type has its own `Storage`, indexed by a compile-time assigned type ID.
   /// - Components are stored densely in `components` where `game_objects[i]` is the owner of `components[i]`.
-  /// - `sparse[g]` maps a game object ID `g` to its component’s dense index, or `INVALID_COMPONENT_INDEX` if the
-  ///   component is absent.
+  /// - `sparse[g]` maps a game object ID `g` to its component’s dense index, or `INVALID_INDEX` if the component is
+  ///   absent.
   ///
   /// Behaviour:
   /// - Adding a component appends it to the dense arrays and records its index in `sparse`.
@@ -198,7 +280,7 @@ class Registry {
         return;
       }
       const size_t index{sparse[game_object_id]};
-      if (index == INVALID_COMPONENT_INDEX) {
+      if (index == INVALID_INDEX) {
         return;
       }
 
@@ -212,28 +294,46 @@ class Registry {
       // Remove the last element from the storage
       components.pop_back();
       game_objects.pop_back();
-      sparse[game_object_id] = INVALID_COMPONENT_INDEX;
+      sparse[game_object_id] = INVALID_INDEX;
     }
   };
 
-  /// The next game object ID to use.
-  GameObjectID next_game_object_id_{0};
+  /// A cache entry for a view, storing the cached game objects that match the component combination for the view.
+  struct ViewCacheEntry {
+    /// The game objects that match the component combination for this cache entry.
+    std::vector<GameObjectID> objects;
 
-  /// The next component type ID to use.
-  inline static std::size_t next_component_type_id_{0};
+    /// The component type IDs that this cache entry depends on, used for dirtying the cache when components are added
+    /// or removed.
+    std::vector<std::size_t> component_type_ids;
+
+    /// A flag indicating whether the cache entry is dirty and needs to be updated.
+    bool dirty{true};
+  };
+
+  /// A tag struct used to identify component types in the registry.
+  struct ComponentTag {};
+
+  /// A tag struct used to identify view types in the registry.
+  struct ViewTag {};
 
   /// Get the component type ID for a given component type.
   ///
   /// @return The component type ID for the given component type.
-  template <typename Component>
-  static auto component_type_id() -> std::size_t {
-    (void)typeid(Component);  // Ignore unused template warning
-    static std::size_t const component_type_id{next_component_type_id_++};
-    return component_type_id;
+  template <typename T, typename Tag>
+  static auto type_id() -> std::size_t {
+    (void)typeid(T);  // Ignore unused template warning
+    if constexpr (std::is_same_v<Tag, ComponentTag>) {
+      static std::size_t const component_type_id{next_component_type_id_++};
+      return component_type_id;
+    } else if constexpr (std::is_same_v<Tag, ViewTag>) {
+      static std::size_t const view_type_id{next_view_type_id_++};
+      return view_type_id;
+    } else {
+      static_assert(std::is_same_v<Tag, ComponentTag> || std::is_same_v<Tag, ViewTag>, "Invalid tag type for type_id");
+      return -1;
+    }
   }
-
-  /// A vector of storages for each component type, indexed by component type ID.
-  std::vector<std::unique_ptr<IStorage>> storages_;
 
   /// Get the storage for a given component type, creating it if it does not exist.
   ///
@@ -242,20 +342,56 @@ class Registry {
   template <typename Component>
   auto get_storage() -> Storage<Component>& {
     // Resize storages vector if needed
-    const std::size_t type_id{component_type_id<Component>()};
-    if (type_id >= storages_.size()) {
-      storages_.resize(type_id + 1);
+    const std::size_t component_type_id{type_id<Component, ComponentTag>()};
+    if (component_type_id >= storages_.size()) {
+      storages_.resize(component_type_id + 1);
     }
 
     // Lazily create storage for this component type
-    if (!storages_[type_id]) {
-      storages_[type_id] = std::make_unique<Storage<Component>>();
+    if (!storages_[component_type_id]) {
+      storages_[component_type_id] = std::make_unique<Storage<Component>>();
     }
-    return *static_cast<Storage<Component>*>(storages_[type_id].get());
+    return *static_cast<Storage<Component>*>(storages_[component_type_id].get());
   }
+
+  /// Mark cached views as dirty, so they will be rebuilt on next access.
+  ///
+  /// @param component_type_id The component type ID that was added or removed or `INVALID_INDEX` to dirty all views.
+  void dirty_views(const std::size_t component_type_id = INVALID_INDEX) {
+    for (auto& [game_objects, component_type_ids, dirty] : view_cache_) {
+      if (component_type_id == INVALID_INDEX ||
+          std::ranges::find(component_type_ids, component_type_id) != component_type_ids.end()) {
+        dirty = true;
+      }
+    }
+  }
+
+  /// A constant representing an invalid index for views, components, and type IDs.
+  inline static std::size_t INVALID_INDEX{static_cast<std::size_t>(-1)};
+
+  /// The next component type ID to use.
+  inline static std::size_t next_component_type_id_{0};
+
+  /// The next view type ID to use.
+  inline static std::size_t next_view_type_id_{0};
+
+  /// The next game object ID to use.
+  GameObjectID next_game_object_id_{0};
+
+  /// A vector of storages for each component type, indexed by the component type ID.
+  std::vector<std::unique_ptr<IStorage>> storages_;
+
+  /// A vector of view cache entries, indexed by the view ID.
+  std::vector<ViewCacheEntry> view_cache_;
 
   /// A vector of booleans indicating whether each game object ID is alive or not, indexed by game object ID.
   std::vector<bool> alive_;
 };
+
+template <typename... Component>
+auto View<Component...>::iterator::operator*() const {
+  const GameObjectID game_object_id{game_objects[index]};
+  return std::tuple<Component&...>{registry->get_component<Component>(game_object_id)...};
+}
 }  // namespace exodus::ecs
 // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)

--- a/tests/ecs/test_registry.cpp
+++ b/tests/ecs/test_registry.cpp
@@ -250,12 +250,124 @@ TEST_F(RegistryFixture, RemoveComponentBeyondSparseSize) {
   ASSERT_FALSE(registry.has(game_object_id_two));
 }
 
-/// Test that Storage::remove() early returns when index == INVALID_COMPONENT_INDEX.
+/// Test that Storage::remove() early returns when index == INVALID_INDEX.
 TEST_F(RegistryFixture, RemoveComponentWithInvalidIndex) {
   const GameObjectID game_object_id{registry.create()};
   registry.add_component<TestComponentOne>(game_object_id, 42);
   registry.destroy(game_object_id);
   registry.destroy(game_object_id);
   ASSERT_FALSE(registry.has(game_object_id));
+}
+
+/// Test that views are cached and reused when accessed multiple times.
+TEST_F(RegistryFixture, ViewCachingBasic) {
+  const GameObjectID game_object_id_one{registry.create()};
+  const GameObjectID game_object_id_two{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_one, 10);
+  registry.add_component<TestComponentOne>(game_object_id_two, 20);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 2);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 2);
+}
+
+/// Test that a view cache is invalidated when a relevant component is added.
+TEST_F(RegistryFixture, ViewCacheInvalidatedOnComponentAdd) {
+  const GameObjectID game_object_id_one{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_one, 10);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 1);
+  const GameObjectID game_object_id_two{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_two, 20);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 2);
+}
+
+/// Test that a view cache is invalidated when a game object is destroyed.
+TEST_F(RegistryFixture, ViewCacheInvalidatedOnDestroy) {
+  const GameObjectID game_object_id_one{registry.create()};
+  const GameObjectID game_object_id_two{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_one, 10);
+  registry.add_component<TestComponentOne>(game_object_id_two, 20);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 2);
+  registry.destroy(game_object_id_one);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 1);
+}
+
+/// Test that view cache is invalidated when a new game object is created.
+TEST_F(RegistryFixture, ViewCacheInvalidatedOnCreate) {
+  const GameObjectID game_object_id_one{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_one, 10);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 1);
+  const GameObjectID game_object_id_two{registry.create()};
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 1);
+  registry.add_component<TestComponentOne>(game_object_id_two, 20);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 2);
+}
+
+/// Test that unrelated component changes don't invalidate unrelated views.
+TEST_F(RegistryFixture, ViewCacheNotInvalidatedByUnrelatedComponents) {
+  const GameObjectID game_object_id_one{registry.create()};
+  const GameObjectID game_object_id_two{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_one, 10);
+  registry.add_component<TestComponentTwo>(game_object_id_two, 20.0F);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 1);
+  const GameObjectID game_object_id_three{registry.create()};
+  registry.add_component<TestComponentTwo>(game_object_id_three, 30.0F);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 1);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentTwo>()), 2);
+}
+
+/// Test that a multi-component view cache is invalidated when any relevant component is added.
+TEST_F(RegistryFixture, MultiComponentViewCacheInvalidation) {
+  const GameObjectID game_object_id_one{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_one, 10);
+  registry.add_component<TestComponentTwo>(game_object_id_one, 20.0F);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne, TestComponentTwo>()), 1);
+  const GameObjectID game_object_id_two{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_two, 30);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne, TestComponentTwo>()), 1);
+  registry.add_component<TestComponentTwo>(game_object_id_two, 40.0F);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne, TestComponentTwo>()), 2);
+}
+
+/// Test that a view cache handles repeated adds of the same component type correctly.
+TEST_F(RegistryFixture, ViewCacheWithRepeatedComponentAdds) {
+  const GameObjectID game_object_id_one{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_one, 10);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 1);
+  registry.add_component<TestComponentOne>(game_object_id_one, 20);
+  const auto count{std::ranges::count_if(registry.view<TestComponentOne>(), [](const auto& tuple) {
+    const auto& [comp]{tuple};
+    return comp.value == 10;
+  })};
+  ASSERT_EQ(count, 1);
+}
+
+/// Test that a view cache is properly invalidated when destroying objects with multiple components.
+TEST_F(RegistryFixture, ViewCacheInvalidatedOnDestroyMultiComponent) {
+  const GameObjectID game_object_id_one{registry.create()};
+  const GameObjectID game_object_id_two{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_one, 10);
+  registry.add_component<TestComponentTwo>(game_object_id_one, 20.0F);
+  registry.add_component<TestComponentOne>(game_object_id_two, 30);
+  registry.add_component<TestComponentTwo>(game_object_id_two, 40.0F);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne, TestComponentTwo>()), 2);
+  registry.destroy(game_object_id_one);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 1);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentTwo>()), 1);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne, TestComponentTwo>()), 1);
+}
+
+/// Test that multiple different view types maintain separate caches.
+TEST_F(RegistryFixture, MultipleDifferentViewCaches) {
+  const GameObjectID game_object_id_one{registry.create()};
+  const GameObjectID game_object_id_two{registry.create()};
+  registry.add_component<TestComponentOne>(game_object_id_one, 10);
+  registry.add_component<TestComponentTwo>(game_object_id_one, 20.0F);
+  registry.add_component<TestComponentOne>(game_object_id_two, 30);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 2);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentTwo>()), 1);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne, TestComponentTwo>()), 1);
+  registry.add_component<TestComponentTwo>(game_object_id_two, 40.0F);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne>()), 2);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentTwo>()), 2);
+  ASSERT_EQ(std::ranges::distance(registry.view<TestComponentOne, TestComponentTwo>()), 2);
 }
 }  // namespace exodus::ecs

--- a/tests/test_factories.cpp
+++ b/tests/test_factories.cpp
@@ -36,7 +36,7 @@ TEST_F(FactoriesFixture, GetTileTexturesReturnsReference) {
 TEST_F(FactoriesFixture, CreateGameObjectInvalidTileTypeDoesNothing) {
   // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   create_game_object(registry, static_cast<generation::TileType>(10), {0.0F, 0.0F});
-  ASSERT_TRUE(registry.view<ecs::components::Transform>().empty());
+  ASSERT_EQ(std::ranges::distance(registry.view<ecs::components::Transform>()), 0);
 }
 
 /// Test that create_game_object() creates a game object for each valid tile type.


### PR DESCRIPTION
## Description of Changes

<!-- Give a brief description of what this pull request aims to achieve
including any issues it may or may not reference -->

This PR optimised `Registry::view()` to cache view iterators so once they're computed once, they are reused until invalidation is required

## Type of Changes

<!-- Select the type of changes that this pull request includes -->

|     | Type                   |
|-----|------------------------|
|       | :bug: Bug Fix          |
|       | :sparkles: New Feature |
| ✓   | :hammer: Refactoring   |
|       | :memo: Miscellaneous   |
