### PR TITLE
Fixed chunk sprites leaning to one side

### DIFF
--- a/src/ecs/systems/chunk_generation.cpp
+++ b/src/ecs/systems/chunk_generation.cpp
@@ -20,12 +20,13 @@ constexpr int CHUNK_GENERATION_RADIUS{2};
 /// @param seed The seed to use for generating the chunk.
 void generate_chunk(Registry& registry, const Vec2i& chunk_pos, const int seed) {
   const auto chunk{generation::generate_chunk(chunk_pos, seed)};
-  for (size_t i{0}; i < chunk.size(); i++) {
-    create_game_object(registry, chunk.at(i),
-                       {static_cast<float>(i % generation::CHUNK_SIZE) +
-                            static_cast<float>(chunk_pos.x * static_cast<int>(generation::CHUNK_SIZE)),
-                        static_cast<float>(i) / static_cast<float>(generation::CHUNK_SIZE) +
-                            static_cast<float>(chunk_pos.y * static_cast<int>(generation::CHUNK_SIZE))});
+  constexpr auto chunk_size{static_cast<int>(generation::CHUNK_SIZE)};
+  for (int i{0}; i < static_cast<int>(chunk.size()); i++) {
+    const int tile_x{i % chunk_size};
+    const int tile_y{i / chunk_size};
+    create_game_object(registry, chunk.at(static_cast<size_t>(i)),
+                       {static_cast<float>(tile_x) + static_cast<float>(chunk_pos.x * chunk_size),
+                        static_cast<float>(tile_y) + static_cast<float>(chunk_pos.y * chunk_size)});
   }
 }
 }  // namespace
@@ -39,8 +40,9 @@ auto get_generated_chunks() -> std::unordered_set<Vec2i>& {
 void chunk_generation_system(Registry& registry) {
   for (const auto& [player, transform] : registry.view<components::Player, components::Transform>()) {
     const Vec2f player_position{transform.position};
-    const Vec2i player_chunk_pos{static_cast<int>(std::floor(player_position.x / generation::CHUNK_SIZE)),
-                                 static_cast<int>(std::floor(player_position.y / generation::CHUNK_SIZE))};
+    const Vec2i player_chunk_pos{
+        static_cast<int>(std::floor(player_position.x / static_cast<float>(generation::CHUNK_SIZE))),
+        static_cast<int>(std::floor(player_position.y / static_cast<float>(generation::CHUNK_SIZE)))};
     for (int chunk_x{-CHUNK_GENERATION_RADIUS}; chunk_x <= CHUNK_GENERATION_RADIUS; chunk_x++) {
       for (int chunk_y{-CHUNK_GENERATION_RADIUS}; chunk_y <= CHUNK_GENERATION_RADIUS; chunk_y++) {
         const Vec2i chunk_pos{player_chunk_pos.x + chunk_x, player_chunk_pos.y + chunk_y};

--- a/tests/ecs/systems/test_chunk_generation.cpp
+++ b/tests/ecs/systems/test_chunk_generation.cpp
@@ -77,4 +77,30 @@ TEST_F(ChunkGenerationFixture, MultiplePlayers) {
   constexpr std::size_t expected_new_game_objects{204800};
   ASSERT_EQ(registry.count(), 2 + expected_new_game_objects);  // Both players are created too
 }
+
+/// Test that chunks are generated for negative player positions.
+TEST_F(ChunkGenerationFixture, GeneratesChunksAtNegativePositions) {
+  const GameObjectID player_id{registry.create()};
+  registry.add_component<components::Player>(player_id);
+  registry.add_component<components::Transform>(player_id, Vec2f{-100.0F, -100.0F});
+  chunk_generation_system(registry);
+
+  // Chunk generation has a radius of 2 so 5x5 chunks each with CHUNK_SIZE*CHUNK_SIZE (4096) tiles
+  constexpr std::size_t expected_new_game_objects{102400};
+  ASSERT_EQ(registry.count(), 1 + expected_new_game_objects);
+}
+
+/// Test that tile positions in negative chunks are correctly grid-aligned.
+TEST_F(ChunkGenerationFixture, NegativeChunkTilePositionsAreGridAligned) {
+  const GameObjectID player_id{registry.create()};
+  registry.add_component<components::Player>(player_id);
+  registry.add_component<components::Transform>(player_id, Vec2f{-100.0F, -100.0F});
+  chunk_generation_system(registry);
+
+  // Verify every generated tile has integer-aligned positions
+  for (const auto& [transform] : registry.view<components::Transform>()) {
+    ASSERT_NEAR(transform.position.x - std::floor(transform.position.x), 0.0F, 1e-5F);
+    ASSERT_NEAR(transform.position.y - std::floor(transform.position.y), 0.0F, 1e-5F);
+  }
+}
 }  // namespace exodus::ecs::systems


### PR DESCRIPTION
## Description of Changes

<!-- Give a brief description of what this pull request aims to achieve
including any issues it may or may not reference -->

This PR fixes a bug with chunk generation where floating point calculations would cause each subsequent tile in a chunk to become more offset than the last, resulting in the chunk "leaning" to one side

## Type of Changes

<!-- Select the type of changes that this pull request includes -->

|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug Fix          |
|       | :sparkles: New Feature |
|       | :hammer: Refactoring   |
|       | :memo: Miscellaneous   |
